### PR TITLE
fix: typo in ik.py — left_pninky_tip → left_pinky_tip

### DIFF
--- a/spider/preprocess/ik.py
+++ b/spider/preprocess/ik.py
@@ -316,7 +316,7 @@ def main(
     # special case: allegro hand
     if robot_type in ["allegro", "metahand"]:
         sites_for_mimic.remove("right_pinky_tip")
-        sites_for_mimic.remove("left_pninky_tip")
+        sites_for_mimic.remove("left_pinky_tip")
 
     if embodiment_type == "right":
         sites_for_mimic = [s for s in sites_for_mimic if "right" in s]


### PR DESCRIPTION
## Summary

- Fix typo `left_pninky_tip` → `left_pinky_tip` in `spider/preprocess/ik.py:319`
- This one-character typo causes IK retargeting to crash with `ValueError: list.remove(x): x not in list` for all robots in the `["allegro", "metahand"]` special case path

## Reproduction

```bash
python -c "
from spider.preprocess.ik import main as run_ik
run_ik(task='pour_tube', dataset_dir='example_datasets', dataset_name='oakink',
       embodiment_type='bimanual', data_id=0, robot_type='allegro',
       show_viewer=False, save_video=False)
"
# ValueError: list.remove(x): x not in list
```

## Test plan

- [x] Verified allegro and metahand IK retarget now runs successfully across all oakink and gigahand tasks

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)