### PR TITLE
fix: lower default sim_dt in ik.py to 0.005 for stability

### DIFF
--- a/spider/preprocess/ik.py
+++ b/spider/preprocess/ik.py
@@ -171,7 +171,7 @@ def main(
     enable_collision: bool = False,
     start_idx: int = 0,
     end_idx: int = -1,
-    sim_dt: float = 0.01,
+    sim_dt: float = 0.005,
     ref_dt: float = 0.02,
     data_id: int = 0,
     open_hand: bool = False,


### PR DESCRIPTION
Allegro IK diverged at sim_dt=0.01 (QACC NaN), while xhand
happened to stay stable. 0.005 matches ik_fast.py and the
*_act configs and is overridable via tyro.